### PR TITLE
Reformat section "Alternatives to Rstudio"

### DIFF
--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -205,7 +205,7 @@ The Environment / History / Connections window shows you lots of useful informat
 Although RStudio is becoming increasingly popular it might not be the best choice for everyone and you certainly don't have to use it to use R effectively. Rather than using an 'all in one' IDE many people choose to use R and a separate script editor to write and execute R code. If you're not familiar with what a script editor is, you can think of it as a bit like a word processor but specifically designed for writing code. Happily, there are many script editors freely available so feel free to download and experiment until you find one you like. Some script editors are only available for certain operating systems and not all are specific to R. Suggestions for script editors are provided below. Which one you choose is up to you: one of the great things about R is that *YOU* get to choose how you want to use R.
 
 ### Advanced text editors
-A light yet efficient way to write R scripts consists in using advanced text editors such as:
+A light yet efficient way to write your R scripts using advanced text editors such as:
 
 - [Atom][atom] (all operating systems)
 - [BBedit][BBedit] (Mac OS)
@@ -216,7 +216,7 @@ A light yet efficient way to write R scripts consists in using advanced text edi
 - [Sublime Text][sublime] (all operating systems)
 
 ### Integrated developement environements
-Those environments are more powerful than simple text editors, and are similar to Rstudio:
+These environments are more powerful than simple text editors, and are similar to RStudio:
 
 - [Emacs][emacs] and its extension [Emacs Speaks Statistics][ess] (all operating systems)
 - [RKWard][rkward] (Linux)

--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -202,30 +202,24 @@ The Environment / History / Connections window shows you lots of useful informat
 
 ## Alternatives to RStudio
 
-Although RStudio is becoming increasingly popular it might not be the best choice for everyone and you certainly don't have to use it to use R effectively. Rather than using an 'all in one' IDE many people choose to use R and a separate script editor to write and execute R code. If you're not familiar with what a script editor is, you can think of it as a bit like a word processor but specifically designed for writing code. Happily, there are many script editors freely available so feel free to download and experiment until you find one you like. Some script editors are only available for certain operating systems and not all are specific to R. Suggestions for script editors are:
+Although RStudio is becoming increasingly popular it might not be the best choice for everyone and you certainly don't have to use it to use R effectively. Rather than using an 'all in one' IDE many people choose to use R and a separate script editor to write and execute R code. If you're not familiar with what a script editor is, you can think of it as a bit like a word processor but specifically designed for writing code. Happily, there are many script editors freely available so feel free to download and experiment until you find one you like. Some script editors are only available for certain operating systems and not all are specific to R. Suggestions for script editors are provided below. Which one you choose is up to you: one of the great things about R is that *YOU* get to choose how you want to use R.
 
-**For windows users**
+### Advanced text editors
+A light yet efficient way to write R scripts consists in using advanced text editors such as:
+- [Atom][atom] (all operating systems)
+- [BBedit][BBedit] (Mac OS)
+- [gedit][gedit] (Linux; comes with most Linux distributions)
+- [MacVim][macvim] (Mac OS)
+- [Nano][nano] (Linux)
+- [Notepad++][notepad] (Windows)
+- [Sublime Text][sublime] (all operating systems)
 
-- [Sublime Text][sublime]
-- [Tinn-R][tinn-r] 
-- [Atom][atom]
-- [Notepad++][notepad]
-
-**For Mac users**
-
-- [Sublime Text][sublime]
-- [BBedit][BBedit] 
-- [Atom][atom]
-- [MacVim][macvim]
-
-**For Linux users**
-
-- [Sublime Text][sublime]
-- gedit (comes with Ubuntu already)
-- [Atom][atom]
-- vim/nano (Console based editors)
-
-Which one you choose is up to you. One of the great things about R is that *YOU* get to choose how you want to use R
+### Integrated developement environements
+Those environments are more powerful than simple text editors, and are similar to Rstudio:
+- [Emacs][emacs] and its extension [Emacs Speaks Statistics][ess] (all operating systems)
+- [RKWard][rkward] (Linux)
+- [Tinn-R][tinn-r] (Windows)
+- [vim][vim] and its extension [NVim-R][nvim-r] (Linux)
 
 ## R packages {#packages}
 

--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -206,6 +206,7 @@ Although RStudio is becoming increasingly popular it might not be the best choic
 
 ### Advanced text editors
 A light yet efficient way to write R scripts consists in using advanced text editors such as:
+
 - [Atom][atom] (all operating systems)
 - [BBedit][BBedit] (Mac OS)
 - [gedit][gedit] (Linux; comes with most Linux distributions)
@@ -216,6 +217,7 @@ A light yet efficient way to write R scripts consists in using advanced text edi
 
 ### Integrated developement environements
 Those environments are more powerful than simple text editors, and are similar to Rstudio:
+
 - [Emacs][emacs] and its extension [Emacs Speaks Statistics][ess] (all operating systems)
 - [RKWard][rkward] (Linux)
 - [Tinn-R][tinn-r] (Windows)

--- a/links.md
+++ b/links.md
@@ -92,12 +92,19 @@
 [here]: https://github.com/r-lib/here
 
 <!--Editors-->
-[tinn-r]: https://sourceforge.net/projects/tinn-r/
 [atom]: https://atom.io/
-[notepad]: https://notepad-plus-plus.org/
 [BBedit]: https://www.barebones.com/products/bbedit/
+[emacs]: https://www.gnu.org/software/emacs/
+[ess]: https://ess.r-project.org/
+[gedit]: https://wiki.gnome.org/Apps/Gedit
 [macvim]: https://github.com/macvim-dev/macvim
+[nano]: https://www.nano-editor.org/
+[notepad]: https://notepad-plus-plus.org/
+[rkward]: https://rkward.kde.org/
 [sublime]: https://www.sublimetext.com/
+[tinn-r]: https://sourceforge.net/projects/tinn-r/
+[vim]: https://www.vim.org/
+[nvim-r]: https://github.com/jalvesaq/Nvim-R
 
 <!--Bioconductor Links-->
 [bioconductor]: https://www.bioconductor.org/


### PR DESCRIPTION
I propose various changes for this section:

- Add Emacs+ESS, Nvim-R and RKWard as alternatives to Rstudio
- Each alternative has now its own URL
- Alternatives are now listed by type (either text editor or advanced IDE) rather than operating system, which avoids duplicates